### PR TITLE
照明と TV への対応

### DIFF
--- a/pyture_remo/appliance.py
+++ b/pyture_remo/appliance.py
@@ -3,6 +3,8 @@
 from typing import List, NoReturn, Optional
 
 from .signal import Signal
+from .light import Light
+from .tv import TV
 
 
 class Appliance:
@@ -18,13 +20,15 @@ class Appliance:
 
     def _set_member(self, data: dict) -> NoReturn:
         self.id: str = data["id"]
-        self.model: str = data["model"]
+        self.model: dict = data["model"]
         self.nickname: str = data["nickname"]
         self.name: str = data["nickname"]  # alias for nickname
         self.image: str = data["image"]
         self.type: str = data["type"]
-        self.settings: str = data["settings"]
-        self.aircon: str = data["aircon"]
+        self.settings: dict = data["settings"]
+        self.aircon: dict = data["aircon"]
+        self.light: Light = Light(self.id, data["light"]) if self.type == "LIGHT" else None
+        self.tv: TV = TV(self.id, data["tv"]) if self.type == "TV" else None
         self.signals: List = [Signal(**signal) for signal in data["signals"]]
 
     def signal(self, name: str) -> (Optional[Signal], bool):

--- a/pyture_remo/button.py
+++ b/pyture_remo/button.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+
+from .api import Api
+
+
+class Button:
+
+    def __str__(self):
+        return f"{self.__class__.__name__}: {self.name}"
+
+    def __init__(self, appliance_id: str, appliance_type: str, name: str = None, image: str = None, label: str = None):
+        self.appliance_id: str = appliance_id
+        self.appliance_type: str = appliance_type
+        self.name: str = name
+        self.image: str = image
+        self.label: str = label
+        self.api: Api = Api.instance()
+
+    def send(self):
+        self.api.post(path=f"/1/appliances/{self.appliance_id}/{self.appliance_type}", data={"button": self.name})

--- a/pyture_remo/light.py
+++ b/pyture_remo/light.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+
+from typing import List, NoReturn, Optional
+
+from .button import Button
+
+class Light:
+
+    def __str__(self):
+        return f"{self.__class__.__name__}: {self.appliance_id}"
+
+    def __init__(self, appliance_id: str, data: dict) -> NoReturn:
+        self.appliance_id: str = appliance_id
+        self.brightness: str = data["state"]["brightness"]
+        self.power: bool = data["state"]["power"] == "on"
+        self.last_button: str = data["state"]["last_button"]
+        self.buttons: List = [Button(appliance_id=appliance_id, appliance_type="light", **button) for button in data["buttons"]]
+
+    def button(self, name: str) -> (Optional[Button], bool):
+        result: Optional[Button] = next(filter(lambda x: name == x.name, self.buttons), None)
+
+        return result, (result is not None)

--- a/pyture_remo/tv.py
+++ b/pyture_remo/tv.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+
+from typing import List, NoReturn, Optional
+
+from .button import Button
+
+class TV:
+
+    def __str__(self):
+        return f"{self.__class__.__name__}: {self.appliance_id}"
+
+    def __init__(self, appliance_id: str, data: dict) -> NoReturn:
+        self.appliance_id: str = appliance_id
+        self.input: str = data["state"]["input"]
+        self.buttons: List = [Button(appliance_id=appliance_id, appliance_type="tv", **button) for button in data["buttons"]]
+
+    def button(self, name: str) -> (Optional[Button], bool):
+        result: Optional[Button] = next(filter(lambda x: name == x.name, self.buttons), None)
+
+        return result, (result is not None)


### PR DESCRIPTION
機器を登録する際に照明や TV として認識されると `Appliance.type` が `LIGHT` や `TV` となり、主要な赤外線信号や状態を `Appliance.light` や `Appliance.tv` を通して扱うことになるため、それらに対応するラッパークラスを作成します。